### PR TITLE
Masked sensitive tokens in logged shell commands

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -6,7 +6,8 @@ def env_has_key(key)
 end
 
 def run_command(command)
-  puts "@@[command] #{command}"
+  masked_command = command.gsub(/--authToken='[^']*'/, "--authToken='*****'")
+  puts "@@[command] #{masked_command}"
   status = nil
   stdout_str = nil
   stderr_str = nil


### PR DESCRIPTION
This workaround has been applied temporarily until the environment variable is properly masked on the backend side.